### PR TITLE
Filter out message not actually processed.

### DIFF
--- a/formandvoid.lua
+++ b/formandvoid.lua
@@ -84,6 +84,15 @@ end
 count = 0
 function process_midi(data)
   local d = midi.to_msg(data)
+  -- Filter out message types not processed below.
+  if d.type ~= "note_on"
+     and d.type ~= "note_off"
+     and d.type ~= "pitchbend"
+     and d.type ~= "key_pressure"
+     and d.type ~= "channel_pressure"
+     and d.type ~= "cc"
+  then return end
+
   local timbre = d.ch - params:get("first channel")
   if d.ch == params:get("main channel") then
       timbre = 0


### PR DESCRIPTION
Filtering out message types which are not actually processed, most imporantly _clock_ which does not have an channel on it, and therefore logs loads of errors in maiden (and eventually disk) when trying to get the timbre near the top of the function. Maybe this is a helpful or useful PR? Let me know if I would better do it some other way?

https://llllllll.co/t/form-and-void/56432/13?u=xmacex

I also looked at filtering channels to only listen to the selected ones, but I don't know what MPE is and seems to send stuff on many channels in parallel or something. and II am not sure how Form and Void listens to channels what the intention is due to my ignorance about MPE... so only filtering by message type for now.

It is making sounds like some kind of frog... cool.